### PR TITLE
Add entry point flag #36

### DIFF
--- a/test/simple_two_funcs.c
+++ b/test/simple_two_funcs.c
@@ -1,0 +1,7 @@
+void func_1(int a, int b, int *x) {
+  *x = a + b;
+}
+
+void func_2(int a, int b, int *x) {
+  *x = a + b;
+}


### PR DESCRIPTION
Example use of new flag:
```
aaron@ralph4:~/Dev/c++/spf-ie$ ./build/bin/spf-ie test/simple_two_funcs.c --print-info
Error while trying to load a compilation database:
Could not auto-detect compilation database for file "test/simple_two_funcs.c"
No compilation database found in /home/aaron/Dev/c++/spf-ie/test or any parent directory
fixed-compilation-database: Error while opening fixed database: No such file or directory
json-compilation-database: Error while opening JSON database: No such file or directory
Running without flags.

Processing: /home/aaron/Dev/c++/spf-ie/test/simple_two_funcs.c
=================================================

FUNCTION: func_1
---------------

Statements:
S0: *$x$ = $a$ + $b$;

Iteration spaces:
S0: { [0] }

Execution schedules:
S0: { [0] -> [0] }

Data spaces: {$a$ int, $b$ int, $x$ int *}

Array reads:
S0:{
    $a$: { [0] -> [0] }
    $b$: { [0] -> [0] }
}

Array writes:
S0: none

FUNCTION: func_2
---------------

Statements:
S0: *$x$ = $a$ + $b$;

Iteration spaces:
S0: { [0] }

Execution schedules:
S0: { [0] -> [0] }

Data spaces: {$a$ int, $b$ int, $x$ int *}

Array reads:
S0:{
    $a$: { [0] -> [0] }
    $b$: { [0] -> [0] }
}

Array writes:
S0: none

aaron@ralph4:~/Dev/c++/spf-ie$ ./build/bin/spf-ie test/simple_two_funcs.c --print-info --entry-point func_2
Error while trying to load a compilation database:
Could not auto-detect compilation database for file "test/simple_two_funcs.c"
No compilation database found in /home/aaron/Dev/c++/spf-ie/test or any parent directory
fixed-compilation-database: Error while opening fixed database: No such file or directory
json-compilation-database: Error while opening JSON database: No such file or directory
Running without flags.

Processing: /home/aaron/Dev/c++/spf-ie/test/simple_two_funcs.c
=================================================

FUNCTION: func_2
---------------

Statements:
S0: *$x$ = $a$ + $b$;

Iteration spaces:
S0: { [0] }

Execution schedules:
S0: { [0] -> [0] }

Data spaces: {$a$ int, $b$ int, $x$ int *}

Array reads:
S0:{
    $a$: { [0] -> [0] }
    $b$: { [0] -> [0] }
}

Array writes:
S0: none

aaron@ralph4:~/Dev/c++/spf-ie$
```

I did notice what was maybe an existing bug when running with `test/nesting_test.c` example when running on a build from the `main` branch:

```
aaron@ralph4:~/Dev/c++/spf-ie$ ./build/bin/spf-ie test/nesting_test.c --print-info
Error while trying to load a compilation database:
Could not auto-detect compilation database for file "test/nesting_test.c"
No compilation database found in /home/aaron/Dev/c++/spf-ie/test or any parent directory
fixed-compilation-database: Error while opening fixed database: No such file or directory
json-compilation-database: Error while opening JSON database: No such file or directory
Running without flags.

Processing: /home/aaron/Dev/c++/spf-ie/test/nesting_test.c
=================================================

FUNCTION: asdf
---------------

Statements:
S0: int i;
S1: int x;
S2: $x__w__0$ = i;
S3: $x$ = $x__w__0$ + 5;

Iteration spaces:
S0: { [0] }
S1: { [0] }
S2: { [i] : i >= 0 && -i + 2 >= 0 }
S3: { [i] : i >= 0 && -i + 2 >= 0 && i - 2 >= 0 }

Execution schedules:
S0: { [0] -> [0] }
S1: { [0] -> [1] }
S2: { [i] -> [2, i, 0] : i - i = 0 }
S3: { [i] -> [2, i, 1] : i - i = 0 }

Data spaces: {$a$ int, $x$ int, $x__w__0$ int}

Array reads:
S0: none
S1: none
S2: none
S3:{
    $x__w__0$: { [i] -> [0] }
}

Array writes:
S0: none
S1: none
S2:{
    $x__w__0$: { [i] -> [0] }
}
S3:{
    $x$: { [i] -> [0] }
}

FUNCTION: main
---------------

ERROR: Found a statement following a return statement. Returns are only allowed at the end of functions.
At /home/aaron/Dev/c++/spf-ie/test/nesting_test.c:14:5:
int i;

aaron@ralph4:~/Dev/c++/spf-ie$ 

```

